### PR TITLE
Drop the broken pair instead of panic

### DIFF
--- a/splice/pair.go
+++ b/splice/pair.go
@@ -12,8 +12,9 @@ import (
 )
 
 type Pair struct {
-	r, w int
-	size int
+	r, w   int
+	size   int
+	closed bool
 }
 
 func (p *Pair) MaxGrow() {
@@ -45,8 +46,12 @@ func (p *Pair) Cap() int {
 }
 
 func (p *Pair) Close() error {
+	if p.closed {
+		return nil
+	}
 	err1 := syscall.Close(p.r)
 	err2 := syscall.Close(p.w)
+	p.closed = true
 	if err1 != nil {
 		return err1
 	}

--- a/splice/pair_linux.go
+++ b/splice/pair_linux.go
@@ -45,9 +45,13 @@ func (p *Pair) discard() error {
 		// all good.
 		return nil
 	} else if err != nil {
-		errR := syscall.Close(p.r)
-		errW := syscall.Close(p.w)
-		p.closed = true
+		var errR error
+		var errW error
+		if !p.closed {
+			errR = syscall.Close(p.r)
+			errW = syscall.Close(p.w)
+			p.closed = true
+		}
 
 		// This can happen if something closed our fd
 		// inadvertently (eg. double close)

--- a/splice/pair_linux.go
+++ b/splice/pair_linux.go
@@ -45,17 +45,11 @@ func (p *Pair) discard() error {
 		// all good.
 		return nil
 	} else if err != nil {
-		var errR error
-		var errW error
-		if !p.closed {
-			errR = syscall.Close(p.r)
-			errW = syscall.Close(p.w)
-			p.closed = true
-		}
+		closeErr := p.Close()
 
 		// This can happen if something closed our fd
 		// inadvertently (eg. double close)
-		err = fmt.Errorf("splicing into /dev/null: %w (close R %d '%v', close W %d '%v')", err, p.r, errR, p.w, errW)
+		err = fmt.Errorf("splicing into /dev/null: %w (close: %v)", err, closeErr)
 		log.Printf("%v\n", err)
 	}
 

--- a/splice/pair_linux.go
+++ b/splice/pair_linux.go
@@ -39,16 +39,20 @@ func (p *Pair) WriteTo(fd uintptr, n int) (int, error) {
 
 const _SPLICE_F_NONBLOCK = 0x2
 
-func (p *Pair) discard() {
+func (p *Pair) discard() error {
 	_, err := syscall.Splice(p.r, nil, devNullFD(), nil, int(p.size), _SPLICE_F_NONBLOCK)
 	if err == syscall.EAGAIN {
 		// all good.
+		return nil
 	} else if err != nil {
 		errR := syscall.Close(p.r)
 		errW := syscall.Close(p.w)
 
 		// This can happen if something closed our fd
 		// inadvertently (eg. double close)
-		log.Panicf("splicing into /dev/null: %v (close R %d '%v', close W %d '%v')", err, p.r, errR, p.w, errW)
+		err = fmt.Errorf("splicing into /dev/null: %w (close R %d '%v', close W %d '%v')", err, p.r, errR, p.w, errW)
+		log.Printf("%v\n", err)
 	}
+
+	return err
 }

--- a/splice/pair_linux.go
+++ b/splice/pair_linux.go
@@ -47,6 +47,7 @@ func (p *Pair) discard() error {
 	} else if err != nil {
 		errR := syscall.Close(p.r)
 		errW := syscall.Close(p.w)
+		p.closed = true
 
 		// This can happen if something closed our fd
 		// inadvertently (eg. double close)

--- a/splice/pool.go
+++ b/splice/pool.go
@@ -95,7 +95,12 @@ func (pp *pairPool) get() (p *Pair, err error) {
 }
 
 func (pp *pairPool) done(p *Pair) {
-	p.discard()
+	if err := p.discard(); err != nil {
+		// When discard error, the pipe of the `Pair` may has broken. Drop the `Pair`.
+		pp.drop(p)
+		return
+	}
+
 	pp.Lock()
 	pp.usedCount--
 	pp.unused = append(pp.unused, p)


### PR DESCRIPTION
#  Description
Drop the broken pair instead of panic.

Actually, currently we can't ensure why the `Pair.discard` failed , here is the source code of `Pair.discard`.
```golang
func (p *Pair) discard() {
  _, err := syscall.Splice(p.r, nil, devNullFD(), nil, int(p.size), _SPLICE_F_NONBLOCK)
  if err == syscall.EAGAIN {
    // all good.
  } else if err != nil {
    errR := syscall.Close(p.r)
    errW := syscall.Close(p.w)

    log.Panicf("splicing into /dev/null: %v (close R %d '%v', close W %d '%v')", err, p.r, errR, p.w, errW)
  }
}
```
According with the code, we know that the `Pair.discard` panics when `syscall.Splice` return an non `syscall.EGAIN` error.
And, from the stack of uinit `panic: splicing into /dev/null: invalid argument (close R 114 '<nil>', close W 116 '<nil>')`, we know that the `syscall.Splice` returned a `invalid argument` error, `syscall.EINVAL` in golang.

According the `syscall.Splice` [document](https://man7.org/linux/man-pages/man2/splice.2.html), there are 5 situations that the `syscall.Splice` will return `syscall.EINVAL` error
```
       //  Rule this situation out. The /dev/null/ support splicing.
       EINVAL The target filesystem doesn't support splicing.

       // Rule this situation out. As the target fie `/dev/null` does not be opened in append mode.
       EINVAL The target file is opened in append mode.

       // Rule this situation out.  As `p.r` always is assigned with a os.Pipe.
       EINVAL Neither of the file descriptors refers to a pipe.

       // Rule this situation out. As  the offset is null. `syscall.Splice(p.r,null...)`
       EINVAL An offset was given for nonseekable device (e.g., a pipe).

      // Rule this situation out. The `fd_in` is `p.r` which is a pipe, the `fd_out` is `/dev/null`
       EINVAL fd_in and fd_out refer to the same pipe
```
Looks like in `Pair.discard`, there is not possible that the `syscall.Splice` fail with `EINVAL`, but it happens. 

So until now, we haven't figured out the root cause of why `Pair.discard` failed with error `EINVAL`

# Context
* https://app.asana.com/1/1200205285860271/project/1201621330828958/task/1210444877986882?focus=true
*  The  stack of uinit when paniced.
```bash
panic: splicing into /dev/null: invalid argument (close R 114 '<nil>', close W 116 '<nil>')

goroutine 1109 [running]:
log.Panicf({0x12035fc?, 0xc0000b4808?}, {0xc00118f958?, 0x7f9283e7ede8?, 0xc0005028c0?})
        /home/owner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/log/log.go:439 +0x65
github.com/hanwen/go-fuse/v2/splice.(*Pair).discard(0xc0004c4408)
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/splice/pair_linux.go:52 +0x1d1
github.com/hanwen/go-fuse/v2/splice.(*pairPool).done(0xc000180540, 0xc0004c4408)
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/splice/pool.go:98 +0x25
github.com/hanwen/go-fuse/v2/splice.Done(...)
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/splice/pool.go:39
github.com/hanwen/go-fuse/v2/fuse.(*Server).trySplice(0xc0001d01a0, {0x18?, 0xcab9e0?, 0xc001488000?}, 0xc0005e78c8, 0xc0004c4000)
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/fuse/splice_linux.go:75 +0x434
github.com/hanwen/go-fuse/v2/fuse.(*Server).systemWrite(0xc0001d01a0, 0xc0005e78c8, {0xc0005e79c0?, 0xc001186000?, 0xc0001a8168?})
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/fuse/server_linux.go:24 +0x9a
github.com/hanwen/go-fuse/v2/fuse.(*Server).write(0xc0001d01a0, 0xc0005e78c8)
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/fuse/server.go:660 +0x21e
github.com/hanwen/go-fuse/v2/fuse.(*Server).handleRequest(0xc0001d01a0, 0xc0005e78c8)
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/fuse/server.go:586 +0x425
github.com/hanwen/go-fuse/v2/fuse.(*Server).loop(0xc0001d01a0, 0x1)
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/fuse/server.go:543 +0x110
created by github.com/hanwen/go-fuse/v2/fuse.(*Server).readRequest in goroutine 1081
        /home/owner/go/pkg/mod/github.com/crafting-dev/go-fuse/v2@v2.6.1-crafting-20250516/fuse/server.go:372 +0x53e
```